### PR TITLE
Enh/es sigma

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -154,7 +154,7 @@ class MuPlusLambda:
 
         if self.local_search is not None:
             assert isinstance(pop.champion.fitness, float)
-            prev_max_fitness: float = pop.champion.fitness
+            prev_avg_fitness: float = np.mean([ind.fitness for ind in combined])
 
             combined_copy = [ind.copy() for ind in combined]
 
@@ -179,7 +179,13 @@ class MuPlusLambda:
 
             combined = self._sort(new_combined)
 
-            assert pop.champion.fitness >= prev_max_fitness
+            avg_fitness: float = np.mean([ind.fitness for ind in combined])
+            if prev_avg_fitness >= avg_fitness:
+                raise RuntimeError(
+                    "The average fitness decreased after executing the local search. This"
+                    "indicates that something went wrong during the"
+                    "optimization. Aborting."
+                )
 
         pop.parents = self._create_new_parent_population(pop.n_parents, combined)
 

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -180,7 +180,7 @@ class MuPlusLambda:
             combined = self._sort(new_combined)
 
             avg_fitness: float = np.mean([ind.fitness for ind in combined])
-            if prev_avg_fitness >= avg_fitness:
+            if prev_avg_fitness > avg_fitness:
                 raise RuntimeError(
                     "The average fitness decreased after executing the local search. This"
                     "indicates that something went wrong during the"

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -24,7 +24,7 @@ class MuPlusLambda:
         *,
         tournament_size: Union[None, int] = None,
         n_processes: int = 1,
-        local_search: Callable[[IndividualBase], None] = lambda combined: None,
+        local_search: Union[None, Callable[[IndividualBase], None]] = None,
         k_local_search: Union[int, None] = None,
         reorder_genome: bool = False,
         hurdle_percentile: List = [0.0]
@@ -152,13 +152,34 @@ class MuPlusLambda:
         combined = self._compute_fitness(combined, objective)
         combined = self._sort(combined)
 
-        n_total = self.n_offsprings + pop.n_parents
-        k_local_search = n_total if self.k_local_search is None else self.k_local_search
-        for idx in range(k_local_search):
-            self.local_search(combined[idx])
+        if self.local_search is not None:
+            assert isinstance(pop.champion.fitness, float)
+            prev_max_fitness: float = pop.champion.fitness
 
-        combined = self._compute_fitness(combined, objective)
-        combined = self._sort(combined)
+            combined_copy = [ind.copy() for ind in combined]
+
+            k_local_search = (
+                len(combined_copy) if self.k_local_search is None else self.k_local_search
+            )
+            for idx in range(k_local_search):
+                self.local_search(combined_copy[idx])
+
+            combined_copy = self._compute_fitness(combined_copy, objective)
+
+            new_combined = []
+            for ind in combined:
+                for ind_copy in combined_copy:
+                    if ind.idx == ind_copy.idx:
+                        assert ind.fitness is not None
+                        assert ind_copy.fitness is not None
+                        if ind.fitness < ind_copy.fitness:
+                            new_combined.append(ind_copy)
+                        else:
+                            new_combined.append(ind)
+
+            combined = self._sort(new_combined)
+
+            assert pop.champion.fitness >= prev_max_fitness
 
         pop.parents = self._create_new_parent_population(pop.n_parents, combined)
 

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -126,7 +126,7 @@ class MuPlusLambda:
         """
 
         if self.reorder_genome:
-            pop.reorder_genome()
+            old_to_new_parameter_names_to_values=pop.reorder_genome()
 
         offsprings = self._create_new_offspring_generation(pop)
 
@@ -162,7 +162,7 @@ class MuPlusLambda:
                 len(combined_copy) if self.k_local_search is None else self.k_local_search
             )
             for idx in range(k_local_search):
-                self.local_search(combined_copy[idx])
+                self.local_search(combined_copy[idx], old_to_new_parameter_names_to_values)
 
             combined_copy = self._compute_fitness(combined_copy, objective)
 

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -327,6 +327,8 @@ class Genome:
 
         self.dna = dna
 
+        return old_to_new_parameter_names_to_values
+
     def _convert_parameter_names(
         self, old_node_idx: int, new_node_idx: int
     ) -> Dict[Tuple[str, str], float]:

--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -129,7 +129,8 @@ class IndividualBase:
 
     @staticmethod
     def _reorder_genome(genome: Genome, rng: np.random.RandomState) -> None:
-        genome.reorder(rng)
+        old_to_new_parameter_names_to_values = genome.reorder(rng)
+        return old_to_new_parameter_names_to_values
 
     @staticmethod
     def _to_func(genome: Genome) -> Callable[[List[float]], List[float]]:
@@ -214,7 +215,8 @@ class IndividualSingleGenome(IndividualBase):
         self._randomize_genome(self.genome, rng)
 
     def reorder_genome(self, rng: np.random.RandomState) -> None:
-        self._reorder_genome(self.genome, rng)
+        old_to_new_parameter_names_to_values=self._reorder_genome(self.genome, rng)
+        return old_to_new_parameter_names_to_values
 
     def to_func(self) -> Callable[[List[float]], List[float]]:
         return self._to_func(self.genome)

--- a/cgp/local_search/__init__.py
+++ b/cgp/local_search/__init__.py
@@ -1,1 +1,2 @@
+from .evolution_strategies import EvolutionStrategies
 from .gradient_based import gradient_based

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class EvolutionStrategies:
     def __init__(
         self,
-        objective: Callable[[Callable[["np.ndarray[float]"], "np.ndarray[float]"]], float],
+        objective: Callable[[IndividualBase], float],
         seed: int,
         *,
         learning_rate_mu: float = 1.0,
@@ -177,7 +177,7 @@ class EvolutionStrategies:
     ) -> float:
         new_ind: IndividualBase = ind.clone()
         new_ind.update_parameters_from_numpy_array(z, params_names)
-        return self.objective(new_ind.to_numpy())
+        return self.objective(new_ind)
 
     def _determine_utility(
         self, s: "np.ndarray[float]", z: "np.ndarray[float]", fitness: "np.ndarray[float]",

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -1,0 +1,218 @@
+import functools
+import math
+import multiprocessing as mp
+from typing import TYPE_CHECKING, Callable, Dict, List, Tuple, Union
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..individual import IndividualBase
+
+
+class EvolutionStrategies:
+    def __init__(
+        self,
+        objective: Callable[[Callable[["np.ndarray[float]"], "np.ndarray[float]"]], float],
+        seed: int,
+        *,
+        learning_rate_mu: float = 1.0,
+        learning_rate_sigma: Union[None, float] = None,
+        population_size: Union[None, int] = None,
+        max_generations: int = 10,
+        min_sigma: float = 1e-6,
+        fitness_shaping: bool = True,
+        mirrored_sampling: bool = True,
+        n_processes: int = 1
+    ) -> None:
+        """Evolution strategies using the natural gradient of multinormal
+        search distributions in natural coordinates.
+
+        Standard deviation of the search distribution for each
+        parameter is stored per individual. Offspring may use the
+        values of their parents if the number of used parameters has
+        not changed. Does not consider covariances between parameters.
+
+        Implementation and default values following Wierstra et
+        al. (2014). Natural evolution strategies. Journal of Machine
+        Learning Research, 15(1), 949-980.
+
+        Parameters
+        ----------
+        individual : Individual
+            Individual for which to perform local search.
+        objective : Callable[[Callable[[np.ndarray[float]], np.ndarray[float]]], float]
+            Objective function used for the local search. Needs to accept
+            an numpy-compatible function as first argument (e.g., from
+            IndividualBase.to_numpy()) and return a float representing the
+            fitness of the individual.
+        seed : int
+            Seed for internal random number generator.
+        learning_rate_mu : float, optional
+            Learning rate for mean of search distribution.
+            Defaults to 1.0.
+        learning_rate_sigma : float, optional
+            Learning rate for standard deviation of search
+            distribution. Defaults to (3 + log(dim)) / (5.0 *
+            sqrt(dim)), where dim is the dimension of the search space.
+        population_size : int, optional
+            Number of samples evaluated per generation. Defaults to 4
+            + floor(3 * log(dim))), where dim is the dimension of the
+            search space..
+        max_generations : int, optional
+            Maximal number of generations. Defaults to 10.
+        min_sigma : float, optional
+            Minimal value for standard deviation of search
+            distribution. Defaults to 1e-6.
+        fitness_shaping : bool, optional
+            Whether to use fitness shaping. Defaults to True.
+        mirrored_sampling : bool, optional
+            Whether to use mirrored sampling. WARNING: Doubles the number
+            of samples per generation. Defaults to True.
+        n_processes : int, optional
+            Number of parallel processes. Defaults to 1.
+
+        """
+        self.objective = objective
+        self.learning_rate_mu = learning_rate_mu
+        self.learning_rate_sigma = learning_rate_sigma
+        self.population_size = population_size
+        self.max_generations = max_generations
+        self.min_sigma = min_sigma
+        self.fitness_shaping = fitness_shaping
+        self.mirrored_sampling = mirrored_sampling
+        self.n_processes = n_processes
+
+        self.rng = np.random.RandomState(seed)
+
+        self.sigma: Dict[int, np.ndarray[float]] = {}
+
+    def __call__(self, ind: "IndividualBase") -> None:
+
+        process_pool: Union[None, mp.pool.Pool]
+        if self.n_processes > 1:
+            process_pool = mp.Pool(processes=self.n_processes)
+        else:
+            process_pool = None
+
+        mu: np.ndarray[float]
+        params_names: List[str]
+        mu, params_names = ind.parameters_to_numpy_array(only_active_nodes=True)
+
+        sigma: np.ndarray[float]
+        if ind.idx in self.sigma:  # try loading sigma
+            sigma = self.sigma[ind.idx]
+            assert len(sigma) == len(mu)
+        elif ind.parent_idx in self.sigma and len(mu) == len(
+            self.sigma[ind.parent_idx]
+        ):  # try loading sigma from parent
+            sigma = self.sigma[ind.parent_idx]
+        else:
+            # as a simple heuristic initialize sigma to 10% of the
+            # mean value
+            sigma = 0.1 * np.abs(mu.copy())
+
+        if len(mu) > 0:
+            if self.learning_rate_sigma is None:
+                learning_rate_sigma = (3 + math.log(len(mu))) / (5.0 * math.sqrt(len(mu)))
+            else:
+                learning_rate_sigma = self.learning_rate_sigma
+
+            if self.population_size is None:
+                population_size = 4 + int(math.floor(3 * math.log(len(mu))))
+            else:
+                population_size = self.population_size
+
+            obj: Callable[[np.ndarray[float]], float] = functools.partial(
+                self._objective_wrapper, ind=ind, params_names=params_names
+            )
+
+            for generation in range(self.max_generations):
+
+                s: np.ndarray[float]
+                z: np.ndarray[float]
+                s, z = self._sample_s_and_z(mu, sigma, population_size)
+
+                fitness: np.ndarray[float]
+                if self.n_processes == 1:
+                    fitness = np.fromiter(map(obj, z), np.float)
+                else:
+                    assert isinstance(process_pool, mp.pool.Pool)
+                    fitness = np.fromiter(process_pool.map(obj, z), np.float)
+
+                s, z, utility = self._determine_utility(s, z, fitness)
+
+                mu, sigma = self._update_parameters_of_search_distribution(
+                    s, utility, learning_rate_sigma, mu, sigma
+                )
+
+                sigma[sigma < self.min_sigma] = self.min_sigma
+
+            ind.update_parameters_from_numpy_array(mu, params_names)
+
+        # WARNING: should not be indented as all individuals should
+        # store their sigma whether they have changed or not to allow
+        # propagation over many generations
+        assert isinstance(ind.idx, int)
+        self.sigma[ind.idx] = sigma.copy()
+
+        if self.n_processes > 1:
+            assert process_pool is not None
+            process_pool.close()
+
+    def _sample_s_and_z(
+        self, mu: np.ndarray, sigma: np.ndarray, population_size: int,
+    ) -> Tuple["np.ndarray[float]", "np.ndarray[float]"]:
+        s: np.ndarray[float] = self.rng.normal(0, 1, size=(population_size, *mu.shape))
+        z: np.ndarray[float] = mu + sigma * s
+
+        if self.mirrored_sampling:
+            z = np.vstack([z, mu - sigma * s])
+            s = np.vstack([s, -s])
+
+        return s, z
+
+    def _objective_wrapper(
+        self, z: "np.ndarray[float]", *, ind: "IndividualBase", params_names: List[str]
+    ) -> float:
+        new_ind: IndividualBase = ind.clone()
+        new_ind.update_parameters_from_numpy_array(z, params_names)
+        return self.objective(new_ind.to_numpy())
+
+    def _determine_utility(
+        self, s: "np.ndarray[float]", z: "np.ndarray[float]", fitness: "np.ndarray[float]",
+    ) -> Tuple["np.ndarray[float]", "np.ndarray[float]", "np.ndarray[float]"]:
+        if self.fitness_shaping:
+            order, utility = self._utility_function(fitness)
+            s = s[order]
+            z = z[order]
+        else:
+            utility = fitness
+
+        return s, z, utility
+
+    def _utility_function(
+        self, fitness: np.ndarray
+    ) -> Tuple["np.ndarray[int]", "np.ndarray[float]"]:
+        n: int = len(fitness)
+        order: np.ndarray[float] = np.argsort(fitness)[::-1]
+
+        fitness = fitness[order]
+
+        utility: np.ndarray[float] = [
+            np.max([0, math.log((n / 2) + 1)]) - math.log(k + 1) for k in range(n)
+        ]
+        utility = utility / np.sum(utility) - 1.0 / n
+
+        return order, utility
+
+    def _update_parameters_of_search_distribution(
+        self,
+        s: np.ndarray,
+        utility: "np.ndarray[float]",
+        learning_rate_sigma,
+        mu: np.ndarray,
+        sigma: np.ndarray,
+    ) -> Tuple["np.ndarray[float]", "np.ndarray[float]"]:
+        mu += self.learning_rate_mu * sigma * np.dot(utility, s)
+        sigma *= np.exp(learning_rate_sigma / 2.0 * np.dot(utility, s ** 2 - 1))
+        return mu, sigma

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -163,7 +163,7 @@ class EvolutionStrategies:
             process_pool.close()
 
     def _sample_s_and_z(
-        self, mu: np.ndarray, sigma: np.ndarray, population_size: int, rng
+        self, mu: np.ndarray, sigma: np.ndarray, population_size: int, rng: "np.random.RandomState"
     ) -> Tuple["np.ndarray[float]", "np.ndarray[float]"]:
         s: np.ndarray[float] = rng.normal(0, 1, size=(population_size, *mu.shape))
         z: np.ndarray[float] = mu + sigma * s

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -73,6 +73,7 @@ class EvolutionStrategies:
 
         """
         self.objective = objective
+        self.seed = seed
         self.learning_rate_mu = learning_rate_mu
         self.learning_rate_sigma = learning_rate_sigma
         self.population_size = population_size
@@ -81,8 +82,6 @@ class EvolutionStrategies:
         self.fitness_shaping = fitness_shaping
         self.mirrored_sampling = mirrored_sampling
         self.n_processes = n_processes
-
-        self.rng = np.random.RandomState(seed)
 
         self.sigma: Dict[int, np.ndarray[float]] = {}
 
@@ -93,6 +92,8 @@ class EvolutionStrategies:
             process_pool = mp.Pool(processes=self.n_processes)
         else:
             process_pool = None
+
+        rng = np.random.RandomState(self.seed)
 
         mu: np.ndarray[float]
         params_names: List[str]
@@ -130,7 +131,7 @@ class EvolutionStrategies:
 
                 s: np.ndarray[float]
                 z: np.ndarray[float]
-                s, z = self._sample_s_and_z(mu, sigma, population_size)
+                s, z = self._sample_s_and_z(mu, sigma, population_size, rng)
 
                 fitness: np.ndarray[float]
                 if self.n_processes == 1:
@@ -160,9 +161,9 @@ class EvolutionStrategies:
             process_pool.close()
 
     def _sample_s_and_z(
-        self, mu: np.ndarray, sigma: np.ndarray, population_size: int,
+        self, mu: np.ndarray, sigma: np.ndarray, population_size: int, rng
     ) -> Tuple["np.ndarray[float]", "np.ndarray[float]"]:
-        s: np.ndarray[float] = self.rng.normal(0, 1, size=(population_size, *mu.shape))
+        s: np.ndarray[float] = rng.normal(0, 1, size=(population_size, *mu.shape))
         z: np.ndarray[float] = mu + sigma * s
 
         if self.mirrored_sampling:

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -146,6 +146,8 @@ class EvolutionStrategies:
                     s, utility, learning_rate_sigma, mu, sigma
                 )
 
+                if np.all(sigma < self.min_sigma):
+                    break
                 sigma[sigma < self.min_sigma] = self.min_sigma
 
             ind.update_parameters_from_numpy_array(mu, params_names)

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class EvolutionStrategies:
     def __init__(
         self,
-        objective: Callable[[IndividualBase], float],
+        objective: Callable[["IndividualBase"], float],
         seed: int,
         *,
         learning_rate_mu: float = 1.0,

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -80,7 +80,7 @@ class EvolutionStrategies:
 
         self.sigma: Dict[int, np.ndarray[float]] = {}
 
-    def __call__(self, ind: "IndividualBase") -> None:
+    def __call__(self, ind: "IndividualBase", old_to_new_parameter_names_to_values) -> None:
 
         rng = np.random.RandomState(self.seed)
 

--- a/cgp/population.py
+++ b/cgp/population.py
@@ -129,4 +129,5 @@ class Population:
         None
         """
         for parent in self.parents:
-            parent.reorder_genome(self.rng)
+            old_to_new_parameter_names_to_values=parent.reorder_genome(self.rng)
+        return old_to_new_parameter_names_to_values

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -1,0 +1,174 @@
+"""
+Example for evolutionary regression with local search via evolution strategies
+==============================================================================
+
+Example demonstrating the use of Cartesian genetic programming for a
+regression task that involves numeric constants. Local search via
+evolution strategies is used to determine numeric leaf values of the
+graph.
+"""
+
+# The docopt str is added explicitly to ensure compatibility with
+# sphinx-gallery.
+docopt_str = """
+  Usage:
+    example_local_search_evolution_strategies.py [--max-generations=<N>]
+
+  Options:
+    -h --help
+    --max-generations=<N>  Maximum number of generations [default: 500]
+
+"""
+
+import functools
+
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.constants
+from docopt import docopt
+
+import cgp
+
+args = docopt(docopt_str)
+
+# %%
+# We first define the target function. Note that this function contains
+# numeric values which are initially not available as constants to the search.
+
+
+def f_target(x):
+    return np.e * x[:, 0] ** 2 + 1.0 + np.pi
+
+
+# %%
+# Then we define the objective function for the evolution. It consists
+# of an inner objective which accepts a NumPy-compatible function as
+# its first argument and returns the mean-squared error between the
+# expression represented by a given individual and the target function
+# evaluated on a set of random points. This inner objective is used by
+# the local search to determine appropriate values for Parameter node
+# and the actual objective function to update the fitness of the
+# individual.
+
+
+def inner_objective(f, seed):
+    """Return a loss for the numpy-compatible function f. Used for
+    calculating the fitness of each individual and for the local
+    search of numeric leaf values.
+
+    """
+
+    rng = np.random.RandomState(seed)
+    batch_size = 500
+    x = rng.uniform(-5, 5, size=(batch_size, 1))
+    y = f(x)
+    return -np.mean((f_target(x) - y[:, 0]) ** 2)
+
+
+def objective(individual, seed):
+    """Objective function of the regression task."""
+
+    if individual.fitness is not None:
+        return individual
+
+    f = individual.to_numpy()
+    individual.fitness = inner_objective(f, seed)
+
+    return individual
+
+
+# %%
+# Next, we define the parameters for the population, the genome of
+# individuals, the evolutionary algorithm, and the local search.
+
+
+population_params = {"n_parents": 1, "mutation_rate": 0.05, "seed": 818821}
+
+genome_params = {
+    "n_inputs": 1,
+    "n_outputs": 1,
+    "n_columns": 36,
+    "n_rows": 1,
+    "levels_back": None,
+    "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.Parameter),
+}
+
+ea_params = {"n_offsprings": 4, "tournament_size": 1, "n_processes": 1, "k_local_search": 2}
+
+evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+
+# restrict the number of steps in the local search; since parameter
+# values are propagated from parents to offsprings, parameter values
+# may be iteratively improved across generations despite the small
+# number of steps per generation
+local_search_params = {"max_generations": 5}
+
+# %%
+# We then create a Population instance and instantiate the local search
+# and evolutionary algorithm.
+
+pop = cgp.Population(**population_params, genome_params=genome_params)
+
+# define the function for local search; an instance of the
+# EvolutionStrategies can be called with an individual as an argument
+# for which the local search is performed
+local_search = cgp.local_search.EvolutionStrategies(
+    objective=functools.partial(inner_objective, seed=population_params["seed"]),
+    seed=population_params["seed"],
+    **local_search_params,
+)
+
+ea = cgp.ea.MuPlusLambda(**ea_params, local_search=local_search)
+
+# %%
+#  We define a recording callback closure for bookkeeping of the progression of the evolution.
+
+
+history = {}
+history["champion"] = []
+history["fitness_parents"] = []
+
+
+def recording_callback(pop):
+    history["champion"].append(pop.champion)
+    history["fitness_parents"].append(pop.fitness_parents())
+
+
+obj = functools.partial(objective, seed=population_params["seed"])
+
+# %%
+# Finally, we call the `evolve` method to perform the evolutionary search.
+
+cgp.evolve(pop, obj, ea, **evolve_params, print_progress=True, callback=recording_callback)
+
+
+# %%
+# After finishing the evolution, we plot the result and log the final
+# evolved expression.
+
+width = 9.0
+fig = plt.figure(figsize=(width, width / scipy.constants.golden))
+
+ax_fitness = fig.add_subplot(121)
+ax_fitness.set_xlabel("Generation")
+ax_fitness.set_ylabel("Fitness")
+ax_fitness.set_yscale("symlog")
+
+ax_function = fig.add_subplot(122)
+ax_function.set_ylabel(r"$f(x)$")
+ax_function.set_xlabel(r"$x$")
+
+
+print(f"Final expression {pop.champion.to_sympy()[0]} with fitness {pop.champion.fitness}")
+
+history_fitness = np.array(history["fitness_parents"])
+ax_fitness.plot(np.max(history_fitness, axis=1), label="Champion")
+ax_fitness.plot(np.mean(history_fitness, axis=1), label="Population mean")
+
+x = np.linspace(-5.0, 5, 100).reshape(-1, 1)
+f = pop.champion.to_func()
+y = [f(xi) for xi in x]
+ax_function.plot(x, f_target(x), lw=2, label="Target")
+ax_function.plot(x, y, lw=1, label="Target", marker="x")
+
+plt.savefig("example_local_search_evolution_strategies.pdf", dpi=300)

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -93,7 +93,13 @@ genome_params = {
     "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.Parameter),
 }
 
-ea_params = {"n_offsprings": 4, "mutation_rate": 0.05, "tournament_size": 1, "n_processes": 1, "k_local_search": 2}
+ea_params = {
+    "n_offsprings": 4,
+    "mutation_rate": 0.05,
+    "tournament_size": 1,
+    "n_processes": 1,
+    "k_local_search": 2,
+}
 
 evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -113,8 +113,8 @@ pop = cgp.Population(**population_params, genome_params=genome_params)
 # EvolutionStrategies can be called with an individual as an argument
 # for which the local search is performed
 local_search = cgp.local_search.EvolutionStrategies(
-    objective=functools.partial(inner_objective, seed=population_params["seed"]),
-    seed=population_params["seed"],
+    objective=functools.partial(inner_objective, seed=population_params["seed"] + 1),
+    seed=population_params["seed"] + 2,
     **local_search_params,
 )
 
@@ -134,7 +134,7 @@ def recording_callback(pop):
     history["fitness_parents"].append(pop.fitness_parents())
 
 
-obj = functools.partial(objective, seed=population_params["seed"])
+obj = functools.partial(objective, seed=population_params["seed"] + 1)
 
 # %%
 # Finally, we call the `evolve` method to perform the evolutionary search.

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -82,7 +82,7 @@ def objective(individual, seed):
 # individuals, the evolutionary algorithm, and the local search.
 
 
-population_params = {"n_parents": 1, "mutation_rate": 0.05, "seed": 818821}
+population_params = {"n_parents": 1, "seed": 818821}
 
 genome_params = {
     "n_inputs": 1,
@@ -93,7 +93,7 @@ genome_params = {
     "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.Parameter),
 }
 
-ea_params = {"n_offsprings": 4, "tournament_size": 1, "n_processes": 1, "k_local_search": 2}
+ea_params = {"n_offsprings": 4, "mutation_rate": 0.05, "tournament_size": 1, "n_processes": 1, "k_local_search": 2}
 
 evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -51,13 +51,14 @@ def f_target(x):
 # individual.
 
 
-def inner_objective(f, seed):
+def inner_objective(ind, seed):
     """Return a loss for the numpy-compatible function f. Used for
     calculating the fitness of each individual and for the local
     search of numeric leaf values.
 
     """
 
+    f = ind.to_numpy()
     rng = np.random.RandomState(seed)
     batch_size = 500
     x = rng.uniform(-5, 5, size=(batch_size, 1))
@@ -68,11 +69,10 @@ def inner_objective(f, seed):
 def objective(individual, seed):
     """Objective function of the regression task."""
 
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
-    f = individual.to_numpy()
-    individual.fitness = inner_objective(f, seed)
+    individual.fitness = inner_objective(individual, seed)
 
     return individual
 

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -87,18 +87,19 @@ population_params = {"n_parents": 1, "seed": 818821}
 genome_params = {
     "n_inputs": 1,
     "n_outputs": 1,
-    "n_columns": 36,
+    "n_columns": 2,
     "n_rows": 1,
-    "levels_back": None,
-    "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.Parameter),
+    "levels_back": 2,
+    "primitives": (cgp.Parameter,),
 }
 
 ea_params = {
     "n_offsprings": 4,
-    "mutation_rate": 0.05,
+    "mutation_rate": 0.05, # avoid output mutation to reduce confusion
     "tournament_size": 1,
-    "n_processes": 1,
     "k_local_search": 2,
+    "n_processes": 1,
+    "reorder_genome": True,
 }
 
 evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -663,3 +663,102 @@ def test_genome_reordering_parameterization_consistency(rng):
 
     with pytest.raises(ValueError):
         genome.reorder(rng)
+
+
+def test_parameters_to_numpy_array():
+
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 1, 2, 1, None, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+    ]
+
+    genome._parameter_names_to_values["<p1>"] = 0.8
+    genome._parameter_names_to_values["<p2>"] = 0.9
+
+    # all parameters
+    expected_params = np.array([0.8, 0.9])
+    expected_params_names = ["<p1>", "<p2>"]
+    params, params_names = genome.parameters_to_numpy_array()
+    assert np.all(params == pytest.approx(expected_params))
+    assert params_names == expected_params_names
+
+    # only parameters of active nodes
+    expected_params = np.array([0.8])
+    expected_params_names = ["<p1>"]
+    params, params_names = genome.parameters_to_numpy_array(only_active_nodes=True)
+    assert np.all(params == pytest.approx(expected_params))
+
+
+def test_update_parameters_from_numpy_array():
+
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 1, 2, 1, None, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+    ]
+
+    params = np.array([0.8, 0.9])
+    params_names = ["<p1>", "<p2>"]
+    any_parameter_changed = genome.update_parameters_from_numpy_array(params, params_names)
+
+    assert any_parameter_changed
+    assert genome._parameter_names_to_values["<p1>"] == pytest.approx(0.8)
+    assert genome._parameter_names_to_values["<p2>"] == pytest.approx(0.9)
+
+    # parameters do not change value
+    any_parameter_changed = genome.update_parameters_from_numpy_array(params, params_names)
+
+    assert not any_parameter_changed
+    assert genome._parameter_names_to_values["<p1>"] == pytest.approx(0.8)
+    assert genome._parameter_names_to_values["<p2>"] == pytest.approx(0.9)
+
+
+def test_parameters_numpy_array_consistency():
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 1, 2, 1, None, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+    ]
+
+    genome._parameter_names_to_values["<p1>"] = 0.8
+    genome._parameter_names_to_values["<p2>"] = 0.9
+
+    genome.update_parameters_from_numpy_array(*genome.parameters_to_numpy_array())
+
+    assert genome._parameter_names_to_values["<p1>"] == pytest.approx(0.8)
+    assert genome._parameter_names_to_values["<p2>"] == pytest.approx(0.9)
+
+    genome._parameter_names_to_values["<p1>"] = 1.1
+    genome._parameter_names_to_values["<p2>"] = 1.2
+
+    genome.update_parameters_from_numpy_array(
+        *genome.parameters_to_numpy_array(only_active_nodes=True)
+    )
+
+    assert genome._parameter_names_to_values["<p1>"] == pytest.approx(1.1)
+    assert genome._parameter_names_to_values["<p2>"] == pytest.approx(1.2)

--- a/test/test_ls_evolution_strategies.py
+++ b/test/test_ls_evolution_strategies.py
@@ -1,0 +1,146 @@
+import numpy as np
+import pytest
+
+import cgp
+from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
+
+
+def test_step_towards_maximum(rng_seed):
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 2, 2, 1, None, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+        ID_OUTPUT_NODE,
+        2,
+    ]
+    ind = cgp.individual.IndividualSingleGenome(genome)
+    ind.idx = 0
+
+    def objective(f):
+        x_dummy = np.zeros((1, 1))  # input, not used
+        target_value = np.array([[1.0, 1.1]])
+        return -np.sum((f(x_dummy) - target_value) ** 2)
+
+    # test increase parameter value if too small
+    ind.genome._parameter_names_to_values["<p1>"] = 0.8
+    ind.genome._parameter_names_to_values["<p2>"] = 0.9
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_generations=1)
+    es(ind)
+    assert ind.genome._parameter_names_to_values["<p1>"] > 0.8
+    assert ind.genome._parameter_names_to_values["<p2>"] > 0.9
+
+    # test decrease parameter value if too large
+    ind.genome._parameter_names_to_values["<p1>"] = 1.1
+    ind.genome._parameter_names_to_values["<p2>"] = 1.2
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_generations=1)
+    es(ind)
+    assert ind.genome._parameter_names_to_values["<p1>"] < 1.1
+    assert ind.genome._parameter_names_to_values["<p2>"] < 1.2
+
+
+def _objective_convergence_to_maximum(f):
+    x_dummy = np.zeros((1, 1))  # input, not used
+    target_value = np.array([[1.0, 1.1]])
+    return -np.sum((f(x_dummy) - target_value) ** 2)
+
+
+def test_convergence_to_maximum(rng_seed):
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 2, 2, 1, None, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+        ID_OUTPUT_NODE,
+        2,
+    ]
+    ind = cgp.individual.IndividualSingleGenome(genome)
+    ind.idx = 0
+
+    # single process
+    ind.genome._parameter_names_to_values["<p1>"] = 0.85
+    ind.genome._parameter_names_to_values["<p2>"] = 0.95
+    es = cgp.local_search.EvolutionStrategies(
+        _objective_convergence_to_maximum, rng_seed, max_generations=60
+    )
+    es(ind)
+    assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome._parameter_names_to_values["<p2>"] == pytest.approx(1.1)
+
+    # two processes
+    ind.genome._parameter_names_to_values["<p1>"] = 0.85
+    ind.genome._parameter_names_to_values["<p2>"] = 0.95
+    es = cgp.local_search.EvolutionStrategies(
+        _objective_convergence_to_maximum, rng_seed, max_generations=60, n_processes=2,
+    )
+    es(ind)
+    assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome._parameter_names_to_values["<p2>"] == pytest.approx(1.1)
+
+
+def test_step_towards_maximum_multi_genome(rng_seed):
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 2, 2, 1, None, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+        ID_OUTPUT_NODE,
+        2,
+    ]
+    genome2 = genome.clone()
+    ind = cgp.individual.IndividualMultiGenome([genome, genome2])
+    ind.idx = 0
+
+    def objective(f):
+        x_dummy = np.zeros((1, 1))  # input, not used
+        target_value = np.array([[1.0, 1.1]])
+        return -np.sum((f[0](x_dummy) - target_value) ** 2) - np.sum(
+            (f[1](x_dummy) - target_value) ** 2
+        )
+
+    # test increase parameter value if too small first genome,
+    # decrease parameter value if too large for second genome
+    ind.genome[0]._parameter_names_to_values["<p1>"] = 0.8
+    ind.genome[0]._parameter_names_to_values["<p2>"] = 0.9
+    ind.genome[1]._parameter_names_to_values["<p1>"] = 1.1
+    ind.genome[1]._parameter_names_to_values["<p2>"] = 1.2
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_generations=2)
+    es(ind)
+    assert ind.genome[0]._parameter_names_to_values["<p1>"] > 0.8
+    assert ind.genome[0]._parameter_names_to_values["<p2>"] > 0.9
+    assert ind.genome[1]._parameter_names_to_values["<p1>"] < 1.1
+    assert ind.genome[1]._parameter_names_to_values["<p2>"] < 1.2
+
+    # test decrease parameter value if too large first genome,
+    # increase parameter value if too small for second genome
+    ind.genome[0]._parameter_names_to_values["<p1>"] = 1.1
+    ind.genome[0]._parameter_names_to_values["<p2>"] = 1.2
+    ind.genome[1]._parameter_names_to_values["<p1>"] = 0.8
+    ind.genome[1]._parameter_names_to_values["<p2>"] = 0.9
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_generations=2)
+    es(ind)
+    assert ind.genome[0]._parameter_names_to_values["<p1>"] < 1.1
+    assert ind.genome[0]._parameter_names_to_values["<p2>"] < 1.2
+    assert ind.genome[1]._parameter_names_to_values["<p1>"] > 0.8
+    assert ind.genome[1]._parameter_names_to_values["<p2>"] > 0.9

--- a/test/test_ls_evolution_strategies.py
+++ b/test/test_ls_evolution_strategies.py
@@ -24,7 +24,8 @@ def test_step_towards_maximum(rng_seed):
     ind = cgp.individual.IndividualSingleGenome(genome)
     ind.idx = 0
 
-    def objective(f):
+    def objective(ind):
+        f = ind.to_numpy()
         x_dummy = np.zeros((1, 1))  # input, not used
         target_value = np.array([[1.0, 1.1]])
         return -np.sum((f(x_dummy) - target_value) ** 2)
@@ -46,7 +47,8 @@ def test_step_towards_maximum(rng_seed):
     assert ind.genome._parameter_names_to_values["<p2>"] < 1.2
 
 
-def _objective_convergence_to_maximum(f):
+def _objective_convergence_to_maximum(ind):
+    f = ind.to_numpy()
     x_dummy = np.zeros((1, 1))  # input, not used
     target_value = np.array([[1.0, 1.1]])
     return -np.sum((f(x_dummy) - target_value) ** 2)
@@ -112,7 +114,8 @@ def test_step_towards_maximum_multi_genome(rng_seed):
     ind = cgp.individual.IndividualMultiGenome([genome, genome2])
     ind.idx = 0
 
-    def objective(f):
+    def objective(ind):
+        f = ind.to_numpy()
         x_dummy = np.zeros((1, 1))  # input, not used
         target_value = np.array([[1.0, 1.1]])
         return -np.sum((f[0](x_dummy) - target_value) ** 2) - np.sum(

--- a/test/test_ls_evolution_strategies.py
+++ b/test/test_ls_evolution_strategies.py
@@ -83,16 +83,6 @@ def test_convergence_to_maximum(rng_seed):
     assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(1.0)
     assert ind.genome._parameter_names_to_values["<p2>"] == pytest.approx(1.1)
 
-    # two processes
-    ind.genome._parameter_names_to_values["<p1>"] = 0.85
-    ind.genome._parameter_names_to_values["<p2>"] = 0.95
-    es = cgp.local_search.EvolutionStrategies(
-        _objective_convergence_to_maximum, rng_seed, max_generations=60, n_processes=2,
-    )
-    es(ind)
-    assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(1.0)
-    assert ind.genome._parameter_names_to_values["<p2>"] == pytest.approx(1.1)
-
 
 def test_step_towards_maximum_multi_genome(rng_seed):
     primitives = (cgp.Parameter,)


### PR DESCRIPTION
I butchered your example a bit, using reorder and only param nodes -> I think the discussion we have about sigma and mu corresponding to the correct param is a problem if we use reorder (especially parameter nodes will be reordered more often). I think looking them up via a dict could be the solution, but this is not implemented yet. 